### PR TITLE
Update 03_associatable_spec.rb

### DIFF
--- a/skeleton/spec/03_associatable_spec.rb
+++ b/skeleton/spec/03_associatable_spec.rb
@@ -61,10 +61,16 @@ describe 'AssocOptions' do
     it '#model_class returns class of associated object' do
       options = BelongsToOptions.new('human')
       expect(options.model_class).to eq(Human)
-      expect(options.table_name).to eq('humans')
 
       options = HasManyOptions.new('cats', 'Human')
       expect(options.model_class).to eq(Cat)
+    end
+    
+    it '#table_name returns table name of associated object' do
+      options = BelongsToOptions.new('human')
+      expect(options.table_name).to eq('humans')
+
+      options = HasManyOptions.new('cats', 'Human')
       expect(options.table_name).to eq('cats')
     end
   end


### PR DESCRIPTION
Was confused for a while because "AssocOptions #model_class returns class of associated object" was failing. This is because that spec tests 2 methods, but the description just mentions 1 (only model class, instead of model class and table name). I split the test into two, one for the model class and one for the table name.